### PR TITLE
Fix defaultLocale property to support variant code without country

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "watcher": "gulp watcher"
   },
   "author": "Onegini",
   "license": "Apache2.0",

--- a/src/main/java/com/onegini/styling/config/BrandAwareLocaleConverter.java
+++ b/src/main/java/com/onegini/styling/config/BrandAwareLocaleConverter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Onegini B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.onegini.styling.config;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.LocaleUtils;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BrandAwareLocaleConverter implements Converter<String, Locale> {
+
+  @Override
+  public Locale convert(final String localeString) {
+    return LocaleUtils.toLocale(localeString);
+  }
+}

--- a/src/main/java/com/onegini/styling/config/MvcConfig.java
+++ b/src/main/java/com/onegini/styling/config/MvcConfig.java
@@ -63,9 +63,9 @@ public class MvcConfig implements WebMvcConfigurer {
   }
 
   @Bean
-  public LocaleResolver localeResolver() {
+  public LocaleResolver localeResolver(final BrandAwareLocaleConverter localeConverter) {
     final SessionLocaleResolver slr = new SessionLocaleResolver();
-    slr.setDefaultLocale(stylingProperties.getDefaultLocale());
+    slr.setDefaultLocale(localeConverter.convert(stylingProperties.getDefaultLocale()));
     return slr;
   }
 

--- a/src/main/java/com/onegini/styling/config/StylingProperties.java
+++ b/src/main/java/com/onegini/styling/config/StylingProperties.java
@@ -40,7 +40,7 @@ public class StylingProperties {
   private String tokenServerDefaultResourcesLocation;
   private String tokenServerCustomResourcesLocation;
   @NotNull
-  private Locale defaultLocale;
+  private String defaultLocale;
 
 
 }

--- a/src/test/java/com/onegini/styling/config/BrandAwareLocaleConverterTest.java
+++ b/src/test/java/com/onegini/styling/config/BrandAwareLocaleConverterTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Onegini B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.onegini.styling.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+
+import org.junit.Test;
+
+public class BrandAwareLocaleConverterTest {
+
+  private BrandAwareLocaleConverter converter = new BrandAwareLocaleConverter();
+
+  @Test
+  public void shouldReturnLocaleWithLanguageWhenProvidingStringWithOnlyLanguage() {
+    final Locale locale = converter.convert("nl");
+
+    assertThat(locale.toLanguageTag()).isEqualTo("nl");
+  }
+
+  @Test
+  public void shouldReturnLocaleWithLanguageAndCountryWhenProvidingStringWithLanguageAndCountry() {
+    final Locale locale = converter.convert("nl_NL");
+
+    assertThat(locale.toLanguageTag()).isEqualTo("nl-NL");
+  }
+
+  @Test
+  public void shouldReturnLocaleWithLanguageAndCountryAndVariantCodeWhenProvidingStringWithLanguageAndCountryAndVariantCode() {
+    final Locale locale = converter.convert("nl_NL_variant");
+
+    assertThat(locale.toLanguageTag()).isEqualTo("nl-NL-variant");
+  }
+
+  @Test
+  public void shouldReturnLocaleWithLanguageAndVariantCodeWhenProvidingStringWithLanguageAndVariantCode() {
+    final Locale locale = converter.convert("nl__variant");
+
+    assertThat(locale.toLanguageTag()).isEqualTo("nl-variant");
+  }
+}

--- a/start-env.py
+++ b/start-env.py
@@ -41,7 +41,7 @@ def openProcesses(build):
         processes.update({'build': subprocess.Popen("mvn clean package", shell=True)})
     else:
         processes.update({'mvn': subprocess.Popen("mvn spring-boot:run", shell=True)})
-        processes.update({'gulp': subprocess.Popen("gulp watcher", shell=True)})
+        processes.update({'gulp': subprocess.Popen("npm run watcher", shell=True)})
     print(processes)
     return processes
 


### PR DESCRIPTION
It was possible to set a default locale with variant code, but only
together with country, which sometime it's not relevant. It was only
possible to set `nl`, `nl_NL_VARIANT`, but it's not possible to set
`nl__VARIANT`.
This fix made a possibility to set locale as `nl__VARIANT`

Also fixed start-env.py script to not require gulp to be installed
globally.